### PR TITLE
Use the up to date ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,5 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.13
     hooks:
-      - id: ruff
-      - id: ruff-format
+    - id: ruff-check
+    - id: ruff-format


### PR DESCRIPTION
The "ruff (legacy alias)" in a pre-commit configuration refers to an older hook identifier that Ruff used before switching to the newer structure. 