### PR TITLE
Add __init__.py file to mark directory as a Python package

### DIFF
--- a/akka/__init__.py
+++ b/akka/__init__.py
@@ -1,0 +1,3 @@
+"""Initialize the package and mark the directory as a Python package."""
+
+from . import main, request


### PR DESCRIPTION
This PR adds an init.py file to allow the directory to be recognized as a Python package. This is essential for correct import resolution and for tools like pytest to discover modules during testing.