### PR TITLE
Refactor CI Workflow: Split into Build/Push and Scan Workflows

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,37 @@
+name: Build and Push Image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@4.2.2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@3.11.1
+
+      - name: Build and push
+        uses: docker/build-push-action@6.18.0
+        with:
+          context: manager
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'platform-engineering-org/akka' }}
+          tags: ghcr.io/${{ github.repository_owner }}/akka-manager:latest
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -1,13 +1,7 @@
-name: Build and Push Docker Image to GCR
+name: Build and Scan Image
 
 on:
   pull_request_target:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
 
 jobs:
   build:
@@ -20,37 +14,19 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@3.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@3.11.1
 
-      - name: Build and push
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
+      - name: Build for scanning
         uses: docker/build-push-action@6.18.0
         with:
           context: manager
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'platform-engineering-org/akka' }}
-          tags: ghcr.io/${{ github.repository_owner }}/akka-manager:latest
-          platforms: linux/amd64,linux/arm64/v8
-
-      - name: Build for scanning
-        if: github.event_name == 'pull_request_target'
-        uses: docker/build-push-action@6.18.0
-        with:
-          context: .
           load: true
           push: false
           tags: akka-manager:pr-${{ github.event.pull_request.number }}
           platforms: linux/amd64
 
       - name: Scan image for vulnerabilities
-        if: github.event_name == 'pull_request_target'
         uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: akka-manager:pr-${{ github.event.pull_request.number }}
@@ -61,7 +37,6 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Read scan results into output
-        if: github.event_name == 'pull_request_target'
         id: read-scan
         run: |
           echo "scan_output<<EOF" >> $GITHUB_OUTPUT
@@ -69,7 +44,6 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get comment ID
-        if: github.event_name == 'pull_request_target'
         id: get-comment
         uses: peter-evans/find-comment@v3.1.0
         with:
@@ -78,7 +52,6 @@ jobs:
           body-includes: '### 🔒 Trivy Scan Results for `akka-manager:pr-${{ github.event.pull_request.number }}`'
 
       - name: Post Trivy scan result as PR comment
-        if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pre Commit
+name: CI
 
 on:
   pull_request:


### PR DESCRIPTION
This PR refactors the existing GitHub Actions workflow by splitting it into two separate workflow files:

build-and-push.yml
Responsible for building the container image and pushing it to the designated container registry.

build-and-scan.yml
Handles building the image and performing vulnerability scanning, then reporting the results.

Motivation
Improve clarity and separation of concerns.

Note: pull-request-target workflow is broken cause changes didn't land in main yet
